### PR TITLE
Adding electron-window-manager to package.json as 'dev dependency'

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "electron-builder": "^21.1.1",
     "electron-debug": "^3.0.1",
     "electron-devtools-installer": "^2.2.4",
+    "electron-window-manager": "^1.0.6",
     "file-loader": "^4.1.0",
     "html-webpack-plugin": "^3.2.0",
     "mini-css-extract-plugin": "^0.8.0",


### PR DESCRIPTION
![missing-dependency](https://user-images.githubusercontent.com/33878228/64434167-59191a80-d096-11e9-980d-6c394a1ebd2c.png)

Require update dependencies
`npm install` or `yarn install`